### PR TITLE
chore: ignore essential folders

### DIFF
--- a/script-delete.sh
+++ b/script-delete.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-# Função para encontrar e listar pastas vazias
+# Lista de pastas que devem ser ignoradas
+IGNORED_DIRS=(
+  "./.git"
+  "./node_modules"
+  "./dist"
+  "./build"
+)
+
+# Função para encontrar e listar pastas vazias, ignorando as cruciais
 find_empty_dirs() {
-  find . -type d -empty  # Busca por diretórios vazios a partir do diretório atual
+  find . -type d -empty | grep -vE "$(printf "|%s" "${IGNORED_DIRS[@]}")"
 }
 
 # Função para excluir a pasta após confirmação
@@ -21,4 +29,3 @@ delete_dir() {
 
 # Rodar o script
 delete_dir
-


### PR DESCRIPTION
Neste PR  https://github.com/sailleribeiro/script-delete-empty-folders/issues/1 foi realizado:

- Criação de "IGNORED_DIRS" : Lista de pastas essenciais que não podem ser exluidas
